### PR TITLE
feat: Add identity choice buttons to chat interface

### DIFF
--- a/backend/scripts/openai/function_calling_example.py
+++ b/backend/scripts/openai/function_calling_example.py
@@ -31,7 +31,7 @@ logger = logging.getLogger(__name__)
 
 # Load environment variables from .env file
 current_file = Path(__file__)
-project_root = current_file.parents[6]
+project_root = current_file.parents[3]
 env_path = project_root / ".env"
 
 # Load environment variables
@@ -101,6 +101,7 @@ weather_function = FunctionTool(
 # Function handlers
 async def calculator(args: Dict[str, Any]) -> str:
     """Handle calculator function calls."""
+    logger.info(f"*****************[FUNCTION] calculator: {args}")
     operation = args["operation"]
     a = args["a"]
     b = args["b"]
@@ -126,6 +127,7 @@ async def get_weather(args: Dict[str, Any]) -> str:
     In a real implementation, this would call a weather API.
     For this example, we'll return mock data.
     """
+    logger.info(f"*****************[FUNCTION] get_weather")
     location = args["location"]
     
     # Mock weather data
@@ -168,10 +170,10 @@ async def main():
     client = OpenAIClient(api_key=API_KEY)
     
     examples = [
-        "What is 25 plus 17?",
-        "What's the weather like in Paris today?",
-        "If I have 120 divided by 4, what do I get?",
-        "What's the weather in Tokyo and New York?",
+        # "What is 25 plus 17?",
+        # "What's the weather like in Paris today?",
+        # "If I have 120 divided by 4, what do I get?",
+        # "What's the weather in Tokyo and New York?",
         "Calculate 15 * 7"
     ]
     

--- a/frontend/apps/coach/src/components/ChatInterface.tsx
+++ b/frontend/apps/coach/src/components/ChatInterface.tsx
@@ -17,7 +17,6 @@ export const ChatInterface: React.FC<Props> = ({ userId, initialMessages = [] })
   const [messages, setMessages] = useState<ChatMessage[]>(initialMessages)
   const [inputMessage, setInputMessage] = useState('')
   const [isLoading, setIsLoading] = useState(false)
-  // Store the most recently proposed identity
   const [proposedIdentity, setProposedIdentity] = useState<Identity | null>(null)
   const messagesEndRef = useRef<HTMLDivElement>(null)
 
@@ -45,15 +44,10 @@ export const ChatInterface: React.FC<Props> = ({ userId, initialMessages = [] })
 
     try {
       const response = await apiClient.sendMessage(userId, userMessage.content, messages)
-      console.log('Received response:', response)
       setMessages(prev => [...prev, { role: 'assistant', content: response.message }])
-      
-      // Store the proposed identity from the response if it exists
       if ('proposed_identity' in response && response.proposed_identity) {
         setProposedIdentity(response.proposed_identity as Identity)
       } else {
-        // Clear the proposed identity if none exists in the response
-        // This ensures we don't show choices for a previously proposed identity
         setProposedIdentity(null)
       }
     } catch (error) {
@@ -83,8 +77,6 @@ export const ChatInterface: React.FC<Props> = ({ userId, initialMessages = [] })
             {message.role === 'assistant' ? (
               <>
                 <MarkdownRenderer content={message.content} />
-                {/* Show identity choice buttons after the message if this is the most recent assistant message
-                    and there's a proposed identity and we're not currently loading */}
                 {index === messages.length - 1 && proposedIdentity && !isLoading && (
                   <IdentityChoice 
                     identity={proposedIdentity}

--- a/frontend/apps/coach/src/components/IdentityChoice.tsx
+++ b/frontend/apps/coach/src/components/IdentityChoice.tsx
@@ -1,0 +1,62 @@
+import React from 'react';
+import { Identity } from '../types/apiTypes';
+
+export interface IdentityChoiceProps {
+  identity: Identity;
+
+  /**
+   * Callback function when a button is clicked
+   * @param response The predefined response text to send
+   */
+  onChoiceSelected: (response: string) => void;
+  disabled: boolean;
+}
+
+/**
+ * Component for displaying identity choice buttons
+ *
+ * These buttons appear when a proposed identity is available
+ * and allow users to quickly respond with canned messages
+ * instead of typing their own responses.
+ *
+ * There are three main actions:
+ * 1. Accept - Confirm the identity as is
+ * 2. Refine - Accept but with some adjustments
+ * 3. Reject - Ask for a different identity
+ */
+export const IdentityChoice: React.FC<IdentityChoiceProps> = ({
+  identity,
+  onChoiceSelected,
+  disabled,
+}) => {
+  return (
+    <div className="identity-choice-buttons">
+      <button
+        onClick={() => onChoiceSelected(`Yes, I like the "${identity.name}" identity.`)}
+        disabled={disabled}
+        className="identity-button accept-button"
+        aria-label="Accept this identity"
+      >
+        I love it!
+      </button>
+      <button
+        onClick={() => onChoiceSelected(`I like this identity but can we adjust it slightly?`)}
+        disabled={disabled}
+        className="identity-button refine-button"
+        aria-label="Refine this identity"
+      >
+        Refine it
+      </button>
+      <button
+        onClick={() =>
+          onChoiceSelected(`This isn't really what I'm looking for. What are some other options?`)
+        }
+        disabled={disabled}
+        className="identity-button reject-button"
+        aria-label="Try another identity"
+      >
+        Not for me
+      </button>
+    </div>
+  );
+};

--- a/frontend/apps/coach/src/styles/chat.css
+++ b/frontend/apps/coach/src/styles/chat.css
@@ -144,6 +144,68 @@
   border-left: 3px solid var(--primary-color);
 }
 
+/* Identity Choice Buttons */
+.identity-choice-buttons {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  margin-top: 16px;
+  animation: fadeIn 0.3s ease;
+}
+
+.identity-button {
+  padding: 10px 16px;
+  border-radius: 20px;
+  font-weight: 500;
+  font-size: 14px;
+  cursor: pointer;
+  transition: all 0.2s ease;
+  border: none;
+  box-shadow: var(--shadow-sm);
+}
+
+.identity-button:hover:not(:disabled) {
+  transform: translateY(-1px);
+  box-shadow: var(--shadow-md);
+}
+
+.identity-button:active:not(:disabled) {
+  transform: translateY(0);
+}
+
+.identity-button:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.identity-button.accept-button {
+  background-color: var(--success-color);
+  color: var(--text-on-primary);
+}
+
+.identity-button.accept-button:hover:not(:disabled) {
+  background-color: var(--success-dark);
+}
+
+.identity-button.refine-button {
+  background-color: var(--primary-color);
+  color: var(--text-on-primary);
+}
+
+.identity-button.refine-button:hover:not(:disabled) {
+  background-color: var(--primary-dark);
+}
+
+.identity-button.reject-button {
+  background-color: var(--background-dark);
+  color: var(--text-color);
+  border: 1px solid var(--primary-light);
+}
+
+.identity-button.reject-button:hover:not(:disabled) {
+  background-color: var(--background-light);
+}
+
 @media (max-width: 768px) {
   .chat-container {
     height: 80vh;
@@ -151,5 +213,14 @@
   
   .message {
     max-width: 85%;
+  }
+  
+  .identity-choice-buttons {
+    flex-direction: column;
+    width: 100%;
+  }
+  
+  .identity-button {
+    width: 100%;
   }
 }

--- a/frontend/apps/coach/src/styles/variables.css
+++ b/frontend/apps/coach/src/styles/variables.css
@@ -18,6 +18,7 @@
   --accent-color: #d0a959; /* Using gold as accent */
   --error-color: #c25450;
   --success-color: #5d9a6f;
+  --success-dark: #4a7c59; /* Darker shade for hover states */
   
   /* Spacing and sizing */
   --border-radius: 12px;

--- a/frontend/apps/coach/src/types/apiTypes.ts
+++ b/frontend/apps/coach/src/types/apiTypes.ts
@@ -35,12 +35,23 @@ export interface CoachRequest {
    */
   context?: ChatMessage[];
 }
-/**
- * Response model for coach API.
- */
+
+export interface Identity {
+  category: string;
+  name: string;
+  affirmation: string;
+  visualization?: Visualization;
+}
+
+export interface Visualization {
+  appearance: string;
+  energy: string;
+  setting: string;
+}
+
 export interface CoachResponse {
-  /**
-   * Coach's response message
-   */
   message: string;
+  proposed_identity?: Identity;
+  confirmed_identity?: Identity;
+  visualization_prompt?: Visualization;
 }


### PR DESCRIPTION
This commit implements a feature that displays quick-response buttons when the coach proposes an identity, allowing users to easily accept, refine, or reject the suggestion without typing custom responses.

Key changes:
- Updated the apiTypes to match the response from the API call
- Created a new IdentityChoice component with three action buttons:
  - Accept the proposed identity
  - Request refinements to the identity
  - Reject the identity and request alternatives
- Enhanced ChatInterface to track and manage proposed identities
- Ensured proposedIdentity state is properly reset when a new response contains no proposed identity
- Implemented responsive design for mobile devices

This feature improves user experience by streamlining interaction with the coach. It also provides an active affirmation that the user wants to continue with the proposed identity. 
This addition sets us up to perform more sophisticated actions on the users behalf when choosing an identity such as updating the users state in the database. 