### PR TITLE
Caseywschmid/action handler update

### DIFF
--- a/backend/src/discovita/service/coach/actions/handler.py
+++ b/backend/src/discovita/service/coach/actions/handler.py
@@ -24,28 +24,20 @@ def _params_to_dict(params: List[Param]) -> Dict:
 def apply_actions(state: CoachState, actions: List[Action] = None) -> CoachState:
     """Apply actions to modify the coaching state."""
     new_state = state.model_copy(deep=True)
-    print(f"Applying actions: {actions[0].type} {type(actions[0].type)}")
     if not actions:
         return new_state
 
     for action in actions:
-        # Convert string action type to enum if necessary
+        # Convert string action type to enum
         action_type = action.type
         if isinstance(action_type, str):
-            try:
-                action_type = ActionType(action_type)
-            except ValueError:
-                print(f"Warning: Invalid action type: {action_type}")
-                continue
+            action_type = ActionType(action_type)
 
-        # Convert params list to dictionary
         params_dict = (
             _params_to_dict(action.params)
             if isinstance(action.params, list)
             else action.params
         )
-
-        print(f"Processing action: {action_type} with params: {params_dict}")
 
         if action_type == ActionType.CREATE_IDENTITY:
             params = CreateIdentityParams(**params_dict)

--- a/backend/src/discovita/service/coach/actions/handler.py
+++ b/backend/src/discovita/service/coach/actions/handler.py
@@ -1,9 +1,9 @@
 """Handler for executing coach actions."""
 
-from typing import List
+from typing import Dict, List
 from uuid import uuid4
 
-from ..models.action import Action, ActionType
+from ..models.action import Action, ActionType, Param
 from ..models.state import CoachState, Identity, IdentityState
 from .models import (
     AcceptIdentityParams,
@@ -16,15 +16,39 @@ from .models import (
 )
 
 
+def _params_to_dict(params: List[Param]) -> Dict:
+    """Convert a list of Param objects to a dictionary."""
+    return {param.name: param.value for param in params}
+
+
 def apply_actions(state: CoachState, actions: List[Action] = None) -> CoachState:
     """Apply actions to modify the coaching state."""
     new_state = state.model_copy(deep=True)
+    print(f"Applying actions: {actions[0].type} {type(actions[0].type)}")
     if not actions:
         return new_state
 
     for action in actions:
-        if action.type == ActionType.CREATE_IDENTITY:
-            params = CreateIdentityParams(**action.params)
+        # Convert string action type to enum if necessary
+        action_type = action.type
+        if isinstance(action_type, str):
+            try:
+                action_type = ActionType(action_type)
+            except ValueError:
+                print(f"Warning: Invalid action type: {action_type}")
+                continue
+
+        # Convert params list to dictionary
+        params_dict = (
+            _params_to_dict(action.params)
+            if isinstance(action.params, list)
+            else action.params
+        )
+
+        print(f"Processing action: {action_type} with params: {params_dict}")
+
+        if action_type == ActionType.CREATE_IDENTITY:
+            params = CreateIdentityParams(**params_dict)
             identity_id = str(uuid4())
             new_state.identities.append(
                 Identity(
@@ -36,40 +60,40 @@ def apply_actions(state: CoachState, actions: List[Action] = None) -> CoachState
                 )
             )
 
-        elif action.type == ActionType.UPDATE_IDENTITY:
-            params = UpdateIdentityParams(**action.params)
+        elif action_type == ActionType.UPDATE_IDENTITY:
+            params = UpdateIdentityParams(**params_dict)
             for identity in new_state.identities:
                 if identity.id == params.id:
                     identity.description = params.description
                     break
 
-        elif action.type == ActionType.ACCEPT_IDENTITY:
-            params = AcceptIdentityParams(**action.params)
+        elif action_type == ActionType.ACCEPT_IDENTITY:
+            params = AcceptIdentityParams(**params_dict)
             for identity in new_state.identities:
                 if identity.id == params.id:
                     identity.state = IdentityState.ACCEPTED
                     break
 
-        elif action.type == ActionType.ACCEPT_IDENTITY_REFINEMENT:
-            params = AcceptIdentityRefinementParams(**action.params)
+        elif action_type == ActionType.ACCEPT_IDENTITY_REFINEMENT:
+            params = AcceptIdentityRefinementParams(**params_dict)
             for identity in new_state.identities:
                 if identity.id == params.id:
                     identity.state = IdentityState.REFINEMENT_COMPLETE
                     break
 
-        elif action.type == ActionType.ADD_IDENTITY_NOTE:
-            params = AddIdentityNoteParams(**action.params)
+        elif action_type == ActionType.ADD_IDENTITY_NOTE:
+            params = AddIdentityNoteParams(**params_dict)
             for identity in new_state.identities:
                 if identity.id == params.id:
                     identity.notes.append(params.note)
                     break
 
-        elif action.type == ActionType.TRANSITION_STATE:
-            params = TransitionStateParams(**action.params)
+        elif action_type == ActionType.TRANSITION_STATE:
+            params = TransitionStateParams(**params_dict)
             new_state.current_state = params.to_state
 
-        elif action.type == ActionType.SELECT_IDENTITY_FOCUS:
-            params = SelectIdentityFocusParams(**action.params)
+        elif action_type == ActionType.SELECT_IDENTITY_FOCUS:
+            params = SelectIdentityFocusParams(**params_dict)
             # Set the current identity ID directly
             new_state.current_identity_id = params.id
 

--- a/backend/src/discovita/service/coach/models/action.py
+++ b/backend/src/discovita/service/coach/models/action.py
@@ -22,7 +22,6 @@ class ActionType(Enum):
     )
 
 
-# TODO: We'll need to ensure that the action params are properly parsed using this new format
 class Param(BaseModel):
     """Parameter for an action."""
 


### PR DESCRIPTION
## Fix action handler to properly process LLM responses

### Problem
The action handler was failing to correctly process actions returned from the LLM due to changes in the Action model when the new OpenAIService was introduced. Action types were being received as strings rather than enum values. Additionally, the handler was attempting to unpack action parameters directly, but the `Action` model defines `params` as a list of `Param` objects.

### Solution
- Added automatic conversion from string action types to their corresponding `ActionType` enum values
- Created a helper function `_params_to_dict()` to transform lists of `Param` objects into dictionaries before passing to parameter models
