### PR TITLE
Add initial message to conversation history

### DIFF
--- a/backend/src/discovita/service/coach/prompt/manager.py
+++ b/backend/src/discovita/service/coach/prompt/manager.py
@@ -1,27 +1,35 @@
 """Prompt manager for coaching service."""
 
-from typing import Dict, Set, Optional
-from pathlib import Path
+from typing import Dict, Optional, Set
 
-from ..models import CoachState, CoachingState, ActionType
-from .models import PromptContext, IdentitySummary
-from .templates import PromptTemplate
+from ..models import ActionType, CoachingState, CoachState, Message
 from .loader import PromptLoader
+from .models import IdentitySummary, PromptContext
+from .templates import PromptTemplate
+
 
 class PromptManager:
     """Manages prompt templates and generates prompts for the coaching system."""
-    
+
     def __init__(self, prompts_dir: Optional[str] = None):
         """Initialize the prompt manager."""
         self.loader = PromptLoader(prompts_dir)
         self.templates: Dict[CoachingState, PromptTemplate] = {}
         self._load_templates()
-    
+
     def _load_templates(self) -> None:
         """Load all prompt templates."""
         for state in CoachingState:
             self.templates[state] = self.loader.load_template(state)
-    
+
+    def get_initial_message(self) -> Message:
+        """
+        Load the initial welcome message from the shared prompts directory.
+        """
+        initial_message_path = self.loader.prompts_dir / "shared" / "initial_message.md"
+        initial_content = self.loader._read_markdown_file(initial_message_path)
+        return Message(role="coach", content=initial_content)
+
     def _build_prompt_context(self, state: CoachState) -> PromptContext:
         """Build prompt context from coach state."""
         current_identity_desc = None
@@ -30,7 +38,7 @@ class PromptManager:
                 if identity.id == state.current_identity_id:
                     current_identity_desc = identity.description
                     break
-            
+
         # Format recent messages from conversation history
         recent_messages = []
         if state.conversation_history:
@@ -40,34 +48,37 @@ class PromptManager:
                     recent_messages.append(f"User: {entry.content}")
                 else:
                     recent_messages.append(f"Coach: {entry.content}")
-            
+
         return PromptContext(
             user_name=state.user_profile.name,
             user_goals=state.user_profile.goals,
             num_identities=len(state.identities),
             current_identity_description=current_identity_desc,
             identities_summary=[
-                IdentitySummary(id=i.id, description=i.description, state=i.state) for i in state.identities
+                IdentitySummary(id=i.id, description=i.description, state=i.state)
+                for i in state.identities
             ],
             phase=state.current_state.value,
-            recent_messages=recent_messages
+            recent_messages=recent_messages,
         )
-    
+
     def get_prompt(self, state: CoachState) -> str:
         """Get a formatted prompt for the current state using the provided context."""
         if state.current_state not in self.templates:
             raise ValueError(f"No template found for state: {state.current_state}")
-            
+
         template = self.templates[state.current_state]
         context = self._build_prompt_context(state)
-        
+
         # Load shared prompt components
-        action_instructions_path = self.loader.prompts_dir / "shared" / "action_instructions.md"
+        action_instructions_path = (
+            self.loader.prompts_dir / "shared" / "action_instructions.md"
+        )
         system_context_path = self.loader.prompts_dir / "shared" / "system_context.md"
-        
+
         action_instructions = self.loader._read_markdown_file(action_instructions_path)
         system_context = self.loader._read_markdown_file(system_context_path)
-        
+
         # Format the template with the context
         formatted_prompt = template.template.format(
             user_name=context.user_name,
@@ -80,41 +91,71 @@ class PromptManager:
             user_summary=context.user_summary(),
             recent_messages=context.format_recent_messages(),
             identities=context.format_identities(),
-            identity_categories=context.format_identity_categories()
+            identity_categories=context.format_identity_categories(),
         )
-        
+
         # Format and add shared components at the beginning
         formatted_action_instructions = action_instructions.format(
             identity_categories=context.format_identity_categories()
         )
-        
+
         # Combine all components
-        formatted_prompt = f"{formatted_action_instructions}\n\n{system_context}\n\n{formatted_prompt}"
-        
+        formatted_prompt = (
+            f"{formatted_action_instructions}\n\n{system_context}\n\n{formatted_prompt}"
+        )
+
         # Add examples if available
         if template.examples:
             examples_text = "\n\n# Examples\n\n"
             for example in template.examples:
-                description = f"## {example.description}\n\n" if example.description else ""
-                examples_text += f"{description}User: {example.user}\n\nCoach: {example.coach}\n\n"
+                description = (
+                    f"## {example.description}\n\n" if example.description else ""
+                )
+                examples_text += (
+                    f"{description}User: {example.user}\n\nCoach: {example.coach}\n\n"
+                )
             formatted_prompt += examples_text
-        
+
         # Add counter-examples if available
         if template.counter_examples:
-            counter_examples_text = "\n\n# Counter-Examples (Do Not Respond Like This)\n\n"
+            counter_examples_text = (
+                "\n\n# Counter-Examples (Do Not Respond Like This)\n\n"
+            )
             for example in template.counter_examples:
-                description = f"## {example.description}\n\n" if example.description else ""
-                counter_examples_text += f"{description}User: {example.user}\n\nCoach: {example.coach}\n\n"
+                description = (
+                    f"## {example.description}\n\n" if example.description else ""
+                )
+                counter_examples_text += (
+                    f"{description}User: {example.user}\n\nCoach: {example.coach}\n\n"
+                )
             formatted_prompt += counter_examples_text
-        
+
         return formatted_prompt
-    
+
     def get_allowed_actions(self, state: CoachingState) -> Set[ActionType]:
         """Get the set of allowed actions for the current state."""
         if state not in self.templates:
             return set()
         return self.templates[state].allowed_actions
-    
+
     def reload_templates(self) -> None:
         """Reload all templates from disk."""
         self._load_templates()
+
+    def add_initial_message_to_state(self, state: CoachState) -> CoachState:
+        """
+        Add the initial welcome message to a CoachState's conversation history.
+        """
+        initial_message = self.get_initial_message()
+
+        updated_state = CoachState(
+            current_state=state.current_state,
+            user_profile=state.user_profile,
+            identities=state.identities.copy() if state.identities else [],
+            proposed_identity=state.proposed_identity,
+            current_identity_id=state.current_identity_id,
+            conversation_history=[initial_message] + (state.conversation_history or []),
+            metadata=state.metadata.copy() if state.metadata else {},
+        )
+
+        return updated_state

--- a/backend/src/discovita/service/coach/prompts/shared/initial_message.md
+++ b/backend/src/discovita/service/coach/prompts/shared/initial_message.md
@@ -1,0 +1,72 @@
+# Identity Creation Exercise – Simple Role-Playing Dialog
+
+Today, we're going to do something incredibly powerful.
+
+We are going to **design your life,** not by forcing actions or setting rigid goals, but by shaping **who you are at your core.**
+
+Most people try to change their lives by **forcing behaviors**—telling themselves, *"I need to work out,"* *"I should eat healthier,"* or *"I have to be more disciplined."* But this approach relies on **willpower**, which fades.
+
+Real transformation doesn't start with action. It starts with **identity.**
+
+💡 Instead of struggling to force yourself to go to the gym, you become **a Warrior who trains daily.**  
+💡 Instead of stressing about money, you become **a Wealth Architect who builds abundance with ease.**  
+💡 Instead of trying to "be more confident," you become **a Confident Icon who radiates self-assurance effortlessly.**
+
+When you **define who you are,** action becomes **automatic.**
+
+## Why Identity First? Because It Shapes Everything Downstream.
+
+We are going to **position you in the world intentionally** by designing an **array of identities** that define:
+✅ **How you show up**  
+✅ **How you move through challenges**  
+✅ **How you build your relationships**  
+✅ **How you experience life itself**
+
+This process isn't about **external labels or expectations.**  
+✅ **Not your dad's values.**  
+✅ **Not your partner's expectations.**  
+✅ **Not society's definition of success.**  
+
+This is about **what lights you up inside.**
+
+When we find the **right identities for you,** you will **feel it.**
+
+💡 It will give you a **surge of energy**—like a puzzle piece snapping into place in your heart.  
+💡 It will **clarify your choices**—because when you know who you are, the right actions become obvious.  
+💡 It will shift you from **forcing action** to **living in alignment.**
+
+## Bringing the External World Inside: Who Are You in Relationship to Your Life?
+
+Instead of seeing different areas of life—**work, fitness, relationships, wealth, health**—as external buckets that you have to manage, we are flipping the perspective:
+
+💡 **Who are you in relationship to your health?** → A Warrior, a Vitality Seeker, an Athlete.  
+💡 **Who are you in relationship to your wealth?** → A Wealth Architect, an Abundant Creator, a Master Investor.  
+💡 **Who are you in relationships?** → A Devoted Partner, a Magnetic Presence, a Deep Connector.
+
+By making this shift, we move from **obligation to ownership.**
+
+Your external world no longer dictates your actions—**your identity does.**
+
+## Let's Design Your Identity Blueprint
+
+Right now, we're exploring—so don't get **stuck in semantics.** You might start with a concept, and later, we'll refine it into a **powerful noun that you fully own.**
+
+💡 If something feels **off, we tweak it.**  
+💡 If something feels **flat, we expand it.**  
+💡 If something **sparks something inside you**, we lean into it.
+
+This process is about finding **the words that make you feel free, powerful, and limitless.**
+
+## Final Thought: The Power of Identity in Daily Life
+
+When this process is complete, you will never have to **force** action again. You will wake up and know:
+
+🔥 *"I am a Warrior, so I train."*  
+🔥 *"I am a Wealth Architect, so I manage my money wisely."*  
+🔥 *"I am a Confident Icon, so I carry myself with certainty."*
+
+And on the days when you slip? That's okay. You will have this **identity map stored in your technology tool, ready to guide you back on track, any time, any day.**
+
+Today, we take the first step.
+
+🚀 **Are you ready?**

--- a/backend/src/discovita/service/coach/service.py
+++ b/backend/src/discovita/service/coach/service.py
@@ -25,12 +25,13 @@ class CoachService:
         self, message: str, state: CoachState
     ) -> ProcessMessageResult:
         """Process a user message and update the coaching state."""
+        if not state.conversation_history:
+            state = self.prompt_manager.add_initial_message_to_state(state)
         state.conversation_history.append(Message(role="user", content=message))
         system_prompt = self.prompt_manager.get_prompt(state)
         formatted_messages = self.open_ai_service.create_messages(
             system_message=system_prompt, messages=state.conversation_history
         )
-        print(CoachLLMResponse.model_json_schema())
 
         response = self.open_ai_service.create_structured_chat_completion(
             model="gpt-4o-2024-08-06",


### PR DESCRIPTION
## Summary
This PR ensures the coach's initial greeting message is consistently included in the conversation history. The introduction phase of the conversation was being dragged out because the chatbot did not have the context of this first message. The bot will now move on to the brainstorming phase much quicker.
## Changes
- Added get_initial_message() method to PromptManager that loads the welcome message from shared/initial_message.md
- Added add_initial_message_to_state() helper to properly inject the initial message into a CoachState's conversation history