### PR TITLE
Coach API response now explicitly includes actions

### DIFF
--- a/backend/src/discovita/api/routes/coach.py
+++ b/backend/src/discovita/api/routes/coach.py
@@ -1,21 +1,23 @@
 """Coach route handlers."""
 
 from fastapi import APIRouter, Depends
+
 from ...service.coach.models import CoachRequest, CoachResponse, CoachState
 from ...service.coach.service import CoachService
 from ..dependencies import get_coach_service
 
 router = APIRouter()
 
+
 @router.post("/user_input", response_model=CoachResponse)
 async def handle_user_input(
-    request: CoachRequest,
-    service: CoachService = Depends(get_coach_service)
+    request: CoachRequest, service: CoachService = Depends(get_coach_service)
 ) -> CoachResponse:
     """Handle user input and get coach response."""
     result = await service.process_message(request.message, request.coach_state)
     return CoachResponse(
         message=result.message,
         coach_state=result.state,
-        final_prompt=result.final_prompt
+        final_prompt=result.final_prompt,
+        actions=result.actions or [],
     )

--- a/backend/src/discovita/service/coach/models/request_response.py
+++ b/backend/src/discovita/service/coach/models/request_response.py
@@ -1,5 +1,8 @@
 """Request and response models for coaching service."""
 
+from typing import List, Optional
+
+from discovita.service.coach.models.action import Action
 from pydantic import BaseModel, Field
 
 from .state import CoachState
@@ -24,6 +27,7 @@ class CoachResponse(BaseModel):
     final_prompt: str = Field(
         "", description="The final prompt used to generate the coach's response"
     )
+    actions: Optional[List[Action]] = Field(description="Actions performed")
 
 
 class CoachStructuredResponse(BaseModel):

--- a/frontend/apps/coach/src/types/apiTypes.ts
+++ b/frontend/apps/coach/src/types/apiTypes.ts
@@ -9,21 +9,26 @@
  * Type of action to perform
  */
 export type ActionType =
-  | "create_identity"
-  | "update_identity"
-  | "accept_identity"
-  | "accept_identity_refinement"
-  | "add_identity_note"
-  | "transition_state"
-  | "select_identity_focus";
+  | 'create_identity'
+  | 'update_identity'
+  | 'accept_identity'
+  | 'accept_identity_refinement'
+  | 'add_identity_note'
+  | 'transition_state'
+  | 'select_identity_focus';
 /**
  * Current state of the coaching session
  */
-export type CoachingState = "introduction" | "identity_brainstorming" | "identity_refinement";
+export type CoachingState = 'introduction' | 'identity_brainstorming' | 'identity_refinement';
 /**
  * Current state of the identity
  */
-export type IdentityState = "proposed" | "accepted" | "refinement_complete";
+export type IdentityState = 'proposed' | 'accepted' | 'refinement_complete';
+
+export interface Param {
+  name: string;
+  value: string | number;
+}
 
 /**
  * An action to be performed on the coaching state.
@@ -33,10 +38,9 @@ export interface Action {
   /**
    * Parameters for the action
    */
-  params?: {
-    [k: string]: unknown;
-  };
+  params?: Param[];
 }
+
 /**
  * Request model for coach API.
  */
@@ -133,6 +137,7 @@ export interface CoachResponse {
    * The final prompt used to generate the coach's response
    */
   final_prompt?: string;
+  actions?: Action[];
 }
 /**
  * Updated state of the coaching session


### PR DESCRIPTION
## Description
This PR updates the coach API by explicitly including `actions` in the response object. It also improves the type definitions for action parameters to make them more structured and type-safe. 
## Changes
- Added `actions` param to the CoachResponse on the backend
- Added `actions?: Action[]` to the frontend CoachResponse interface
- Created a new Param interface to better structure action parameters for the frontend
- Modified Action.params to use the new Param[] type instead of an unstructured object