### PR TITLE
Updated the Coach State Visualizer to show actions

### DIFF
--- a/frontend/apps/coach/src/components/coach-state-visualizer/CoachStateVisualizer.tsx
+++ b/frontend/apps/coach/src/components/coach-state-visualizer/CoachStateVisualizer.tsx
@@ -36,7 +36,7 @@ export const CoachStateVisualizer: React.FC<CoachStateVisualizerProps> = ({
   const prevStateRef = useRef<null | typeof coachState>(null);
   const prevResponseRef = useRef<undefined | typeof lastResponse>(undefined);
   const prevActionsRef = useRef<null | ExtractedActions>(null);
-  const extractedActionsRef = useRef<ExtractedActions>(extractActions(coachState));
+  const extractedActionsRef = useRef<ExtractedActions>(extractActions(coachState, lastResponse));
   const tabsConfig = getTabsConfig();
 
   // Toggle section expansion
@@ -64,7 +64,7 @@ export const CoachStateVisualizer: React.FC<CoachStateVisualizerProps> = ({
   // Detect changes in data when state or response updates
   useEffect(() => {
     // Extract current actions
-    const currentActions = extractActions(coachState);
+    const currentActions = extractActions(coachState, lastResponse);
     extractedActionsRef.current = currentActions;
 
     // Skip first render

--- a/frontend/apps/coach/src/components/coach-state-visualizer/utils/changeDetection.ts
+++ b/frontend/apps/coach/src/components/coach-state-visualizer/utils/changeDetection.ts
@@ -103,9 +103,19 @@ export const detectPromptTabChanges = (
  */
 export const detectActionsTabChanges = (
   prevActions: ExtractedActions | null,
-  currentActions: ExtractedActions
+  currentActions: ExtractedActions,
+  prevResponse?: CoachResponse,
+  currentResponse?: CoachResponse
 ): boolean => {
   if (!prevActions) return false;
+
+  // Check if response actions have changed
+  const prevResponseActions = prevResponse?.actions || [];
+  const currentResponseActions = currentResponse?.actions || [];
+
+  if (hasChanged(prevResponseActions, currentResponseActions)) {
+    return true;
+  }
 
   return (
     hasChanged(prevActions.actionsTaken, currentActions.actionsTaken) ||
@@ -184,7 +194,12 @@ export const detectAllTabChanges = (
   }
 
   if (currentTab !== TabName.ACTIONS) {
-    updates[TabName.ACTIONS] = detectActionsTabChanges(prevActions, currentActions);
+    updates[TabName.ACTIONS] = detectActionsTabChanges(
+      prevActions,
+      currentActions,
+      prevResponse,
+      currentResponse
+    );
   }
 
   if (currentTab !== TabName.IDENTITIES) {

--- a/frontend/apps/coach/src/components/coach-state-visualizer/utils/dataUtils.ts
+++ b/frontend/apps/coach/src/components/coach-state-visualizer/utils/dataUtils.ts
@@ -1,17 +1,67 @@
-import { CoachState } from '../../../types/apiTypes';
+import { CoachState, CoachResponse, Action } from '../../../types/apiTypes';
 import { ExtractedActions } from '../types';
+
+// Map to track actions by user session
+// Key is user name + first message timestamp (as a unique session identifier)
+const actionsBySession: Record<string, Action[]> = {};
+
+/**
+ * Gets a unique identifier for the current user session
+ *
+ * @param state - The coach state containing user information
+ * @returns A string identifier unique to this session
+ */
+const getSessionKey = (state: CoachState): string => {
+  const userName = state.user_profile?.name || 'unknown';
+  const firstMsgTime =
+    state.conversation_history && state.conversation_history.length > 0
+      ? JSON.stringify(state.conversation_history[0])
+      : Date.now().toString();
+
+  return `${userName}-${firstMsgTime}`;
+};
 
 /**
  * Extracts available actions and actions taken from the coach state metadata
+ * and direct actions from the response, maintaining a history of all actions seen
  *
  * @param coachState - The current state of the coach
+ * @param lastResponse - The last API response which may contain actions
  * @returns Object containing available actions and actions taken
  */
-export const extractActions = (coachState: CoachState): ExtractedActions => {
+export const extractActions = (
+  coachState: CoachState,
+  lastResponse?: CoachResponse
+): ExtractedActions => {
   const metadata = coachState.metadata || {};
+  const sessionKey = getSessionKey(coachState);
+
+  // Initialize session entry if needed
+  if (!actionsBySession[sessionKey]) {
+    actionsBySession[sessionKey] = [];
+  }
+
+  // Get new explicit actions from response
+  const responseActions = lastResponse?.actions || [];
+
+  // Add response actions to our session history if they're new
+  if (responseActions.length > 0) {
+    responseActions.forEach(responseAction => {
+      const actionAsString = JSON.stringify(responseAction);
+      const isDuplicate = actionsBySession[sessionKey].some(
+        existingAction => JSON.stringify(existingAction) === actionAsString
+      );
+
+      if (!isDuplicate) {
+        actionsBySession[sessionKey].push(responseAction);
+      }
+    });
+  }
+
+  // Return both metadata actions and our accumulated history for this session
   return {
     availableActions: (metadata.available_actions as string[]) || [],
-    actionsTaken: (metadata.actions_taken as any[]) || [],
+    actionsTaken: actionsBySession[sessionKey],
   };
 };
 

--- a/frontend/apps/coach/src/components/coach-state-visualizer/utils/renderUtils.tsx
+++ b/frontend/apps/coach/src/components/coach-state-visualizer/utils/renderUtils.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { CoachResponse } from '../../../types/apiTypes';
+import { CoachResponse, Action } from '../../../types/apiTypes';
 import MarkdownRenderer from '../../MarkdownRenderer';
 import { copyToClipboard } from './dataUtils';
 
@@ -43,6 +43,85 @@ export const renderJsonSection = (
       </div>
 
       {isExpanded && <pre className="json-content">{JSON.stringify(data, null, 2)}</pre>}
+    </div>
+  );
+};
+
+/**
+ * Renders actions in a visually appealing way with syntax highlighting
+ *
+ * @param title - Section title
+ * @param actions - Array of actions to display
+ * @param sectionKey - Unique key for the section
+ * @param isExpanded - Whether the section is expanded
+ * @param toggleSection - Function to toggle section expansion
+ * @returns JSX element for the section
+ */
+export const renderActionsSection = (
+  title: string,
+  actions: Action[],
+  sectionKey: string,
+  isExpanded: boolean,
+  toggleSection: (section: string) => void
+): JSX.Element | null => {
+  if (!actions || actions.length === 0) return null;
+
+  // Single color for all action types
+  const actionColor = 'var(--primary-color)'; // Use the primary color from variables.css
+
+  return (
+    <div className="state-section">
+      <div className="section-header" onClick={() => toggleSection(sectionKey)}>
+        <h3>{title}</h3>
+        <div className="section-controls">
+          <button
+            className="copy-button"
+            onClick={e => {
+              e.stopPropagation();
+              copyToClipboard(actions);
+            }}
+          >
+            Copy
+          </button>
+          <span className={`expand-icon ${isExpanded ? 'expanded' : ''}`}>
+            {isExpanded ? '▼' : '▶'}
+          </span>
+        </div>
+      </div>
+
+      {isExpanded && (
+        <div className="actions-container">
+          {actions.map((action, index) => (
+            <div key={index} className="action-card">
+              <div className="action-type" style={{ backgroundColor: actionColor }}>
+                {action.type}
+              </div>
+              <div className="action-params">
+                {action.params && action.params.length > 0 ? (
+                  <table className="params-table">
+                    <thead>
+                      <tr>
+                        <th>Parameter</th>
+                        <th>Value</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {action.params.map((param, pIndex) => (
+                        <tr key={pIndex}>
+                          <td className="param-name">{param.name}</td>
+                          <td className="param-value">{JSON.stringify(param.value)}</td>
+                        </tr>
+                      ))}
+                    </tbody>
+                  </table>
+                ) : (
+                  <div className="no-params">No parameters</div>
+                )}
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
     </div>
   );
 };

--- a/frontend/apps/coach/src/components/coach-state-visualizer/utils/tabConfiguration.ts
+++ b/frontend/apps/coach/src/components/coach-state-visualizer/utils/tabConfiguration.ts
@@ -12,8 +12,9 @@ export const getDefaultExpandedSections = (): ExpandedSectionsConfig => ({
   proposedIdentity: true,
   prompt: true,
   history: true,
-  actionsTaken: true,
+  actionHistory: true,
   availableActions: true,
+  currentActions: true,
 });
 
 /**

--- a/frontend/apps/coach/src/styles/coach-state-visualizer.css
+++ b/frontend/apps/coach/src/styles/coach-state-visualizer.css
@@ -147,6 +147,84 @@
   transform: rotate(0deg);
 }
 
+/* Actions Container Styling */
+.coach-state-visualizer .actions-container {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  padding: 16px;
+  max-height: 500px;
+  overflow-y: auto;
+}
+
+.coach-state-visualizer .action-card {
+  border-radius: var(--border-radius);
+  border: 1px solid var(--border-color);
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+  overflow: hidden;
+  background-color: #fff;
+  transition: transform 0.2s, box-shadow 0.2s;
+}
+
+.coach-state-visualizer .action-card:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.15);
+}
+
+.coach-state-visualizer .action-type {
+  padding: 10px 16px;
+  color: white;
+  font-weight: 600;
+  font-size: 0.9rem;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+}
+
+.coach-state-visualizer .action-params {
+  padding: 12px;
+}
+
+.coach-state-visualizer .no-params {
+  color: #888;
+  font-style: italic;
+  text-align: center;
+  padding: 8px;
+}
+
+.coach-state-visualizer .params-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.9rem;
+}
+
+.coach-state-visualizer .params-table th,
+.coach-state-visualizer .params-table td {
+  padding: 8px 12px;
+  text-align: left;
+  border-bottom: 1px solid #eee;
+}
+
+.coach-state-visualizer .params-table th {
+  background-color: #f8f8f8;
+  font-weight: 600;
+  color: #555;
+}
+
+.coach-state-visualizer .param-name {
+  font-weight: 500;
+  color: #555;
+  width: 40%;
+}
+
+.coach-state-visualizer .param-value {
+  font-family: monospace;
+  background-color: #f9f9f9;
+  padding: 4px 8px;
+  border-radius: 3px;
+  word-break: break-word;
+  max-width: 60%;
+}
+
 /* Empty state styling */
 .coach-state-visualizer .empty-state {
   padding: 24px;


### PR DESCRIPTION
## Description
This PR updates the Coach State Visualizer component to properly display actions that are now explicitly included in the API response.
## Changes
- Modified the extractActions function calls to pass lastResponse as a parameter
- Updated the visualizer to read actions directly from the response object
- Improved action tracking to properly display both current and historical actions for the session